### PR TITLE
Fixes normal map textures naming.

### DIFF
--- a/BlenderAddOn/o3dexport/__init__.py
+++ b/BlenderAddOn/o3dexport/__init__.py
@@ -20,7 +20,7 @@ import bpy
 bl_info = {
     "name": "O3DEXPORT: Exports scenes, meshes, materials and textures to O3DE.",
     "author": "Galib F. Arrieta",
-    "version": (1, 0, 1),
+    "version": (1, 0, 2),
     "blender": (4, 1, 0),
     "location": "3D View > UI (Right Panel) > O3DEXPORT Tab",
     "description": ("Script to export scenes, meshes, materials and textures to O3DE"),

--- a/BlenderAddOn/o3dexport/exporter.py
+++ b/BlenderAddOn/o3dexport/exporter.py
@@ -88,14 +88,16 @@ def ExportAssetsAndSceneGraph(
     if not exportSettings.CreateOutputDirs():
         raise Exception("Failed to create output directories")
     print("O3DEXPORT: Created output directories")
-    # First let's export the textures
-    for _, textureAsset in sceneGraph.GetTexturesDictionary().items():
-        for itor in texture_exporter.ExportTextureAsset(exportSettings, textureAsset):
-            yield itor
-    # Next, export the materials
+    # First, export the materials
+    # We export materials before textures because when exporting material we may update
+    # some TextureAsset(s) as Normal Maps, which changes their sanitized name.
     for materialName, material in sceneGraph.GetMaterialsDictionary().items():
         _ExportMaterial(exportSettings, material, sceneGraph.GetTexturesDictionary())
         yield f"O3DEXPORT: Exported Material '{materialName}'"
+    # Next, let's export the textures
+    for _, textureAsset in sceneGraph.GetTexturesDictionary().items():
+        for itor in texture_exporter.ExportTextureAsset(exportSettings, textureAsset):
+            yield itor
 
     # Next, export the meshes
     for meshName, meshAsset in sceneGraph.GetMeshesDictionary().items():

--- a/BlenderAddOn/o3dexport/imageutils.py
+++ b/BlenderAddOn/o3dexport/imageutils.py
@@ -18,7 +18,7 @@ def LoadImageFileAsImageBuf(imageFilePath: str) -> oiio.ImageBuf:
     return oiio.ImageBuf(imageFilePath)
 
 def CreateImageBufFromColorChannel(imageBuf: oiio.ImageBuf, channel: int) -> oiio.ImageBuf:
-    singleChannelImageBuf = oiio.ImageBugAlgo.channels(imageBuf, (channel,))
+    singleChannelImageBuf = oiio.ImageBufAlgo.channels(imageBuf, (channel,))
     return singleChannelImageBuf
 
 # Old version using PIL, but required manual installation of `pillow`

--- a/BlenderAddOn/o3dexport/o3material.py
+++ b/BlenderAddOn/o3dexport/o3material.py
@@ -331,10 +331,14 @@ class O3Material:
         return jsonStr
 
     def _GetSanitizedTexturePath(
-        self, posixAssetsRelativeTexturePath: str, textureName: str, colorChannel: str
+        self, posixAssetsRelativeTexturePath: str, textureName: str, colorChannel: str, isNormalMap: bool = False
     ) -> str:
         if textureName == "":
             return textureName
+        if isNormalMap:
+            self.texturesDictionary[
+                textureName
+            ].SanitizeNameAsNormalMap()
         if colorChannel == "":
             # This is a regular texture that is sampled for all available color channels
             sanitizedTextureName = self.texturesDictionary[
@@ -433,7 +437,7 @@ class O3Material:
                         else ""
                     )
                     dstDict["normal.textureMap"] = self._GetSanitizedTexturePath(
-                        posixAssetsRelativeTexturePath, textureName, colorChannel
+                        posixAssetsRelativeTexturePath, textureName, colorChannel, isNormalMap=True
                     )
                     dstDict["normal.useTexture"] = True
                 else:

--- a/BlenderAddOn/o3dexport/texture_exporter.py
+++ b/BlenderAddOn/o3dexport/texture_exporter.py
@@ -39,7 +39,7 @@ def _CreateResampledTexture(
     newImage = imageutils.CreateImageBufFromColorChannel(
         originalImageAsImageBuf, colorChhanelId
     )
-    newImage.save(resampledFinalOutputPath)
+    newImage.write(resampledFinalOutputPath)
     print(f"Created '{resampledFinalOutputPath}'")
 
 

--- a/Editor/Scripts/o3dimport/docs/component_properties.md
+++ b/Editor/Scripts/o3dimport/docs/component_properties.md
@@ -32,45 +32,59 @@
 
 # Properties of Materia Component
 ```
-Info: LOD Materials (AZStd::vector<AZStd::vector<EditorMaterialComponentSlot, allocator>, allocator>,NotVisible)
-
 Info: Controller|Materials (AZStd::unordered_map<AZ::Render::MaterialAssignmentId, AZ::Render::MaterialAssignment, AZStd::hash<AZ::Render::MaterialAssignmentId>, AZStd::equal_to<AZ::Render::MaterialAssignmentId>, allocator>,Visible)
+
+Info: Controller|Materials|[0] (AZStd::pair<AZ::Render::MaterialAssignmentId, AZ::Render::MaterialAssignment>,Visible)
+Info: Controller|Materials|[0]|Key<AZ::Render::MaterialAssignmentId> (AZ::Render::MaterialAssignmentId,Visible)
+Info: Controller|Materials|[0]|Value<AZ::Render::MaterialAssignment> (AZ::Render::MaterialAssignment,Visible)
+Info: Controller|Materials|[0]|Value<AZ::Render::MaterialAssignment>|Property Overrides (AZStd::unordered_map<Name, AZStd::any, AZStd::hash<Name>, AZStd::equal_to<Name>, allocator>,Visible)
+
+
+
+
+Info: Controller|Materials|[1] (AZStd::pair<AZ::Render::MaterialAssignmentId, AZ::Render::MaterialAssignment>,Visible)
+Info: Controller|Materials|[1]|Value<AZ::Render::MaterialAssignment>|Property Overrides (AZStd::unordered_map<Name, AZStd::any, AZStd::hash<Name>, AZStd::equal_to<Name>, allocator>,Visible)
+Info: Controller|Materials|[1]|Value<AZ::Render::MaterialAssignment> (AZ::Render::MaterialAssignment,Visible)
+Info: Controller|Materials|[1]|Key<AZ::Render::MaterialAssignmentId> (AZ::Render::MaterialAssignmentId,Visible)
+
+
+Info: Controller|Materials|[2] (AZStd::pair<AZ::Render::MaterialAssignmentId, AZ::Render::MaterialAssignment>,Visible)
+Info: Controller|Materials|[2]|Value<AZ::Render::MaterialAssignment>|Property Overrides (AZStd::unordered_map<Name, AZStd::any, AZStd::hash<Name>, AZStd::equal_to<Name>, allocator>,Visible)
+Info: Controller|Materials|[2]|Value<AZ::Render::MaterialAssignment> (AZ::Render::MaterialAssignment,Visible)
+Info: Controller|Materials|[2]|Key<AZ::Render::MaterialAssignmentId> (AZ::Render::MaterialAssignmentId,Visible)
 
 Info: Model Materials (AZStd::vector<EditorMaterialComponentSlot, allocator>,Visible)
 
-Info: Controller|Materials|[0] (AZStd::pair<AZ::Render::MaterialAssignmentId, AZ::Render::MaterialAssignment>,Visible)
 
-Info: Controller|Materials|[0]|Value<AZ::Render::MaterialAssignment> (AZ::Render::MaterialAssignment,Visible)
 
+
+Info: LOD Materials (AZStd::vector<AZStd::vector<EditorMaterialComponentSlot, allocator>, allocator>,NotVisible)
 Info: LOD Materials|LOD 0 (AZStd::vector<EditorMaterialComponentSlot, allocator>,Visible)
 
-Info: Controller|Materials|[0]|Key<AZ::Render::MaterialAssignmentId> (AZ::Render::MaterialAssignmentId,Visible)
 
-Info: Controller|Materials|[0]|Value<AZ::Render::MaterialAssignment>|Property Overrides (AZStd::unordered_map<Name, AZStd::any, AZStd::hash<Name>, AZStd::equal_to<Name>, allocator>,Visible)
-
-|LOD Index: ('AZ::u64', 'Visible')
-
-|Material Slot Stable Id: ('unsigned int', 'Visible')
-
-Default Material|Material Slot Stable Id: ('unsigned int', 'Visible')
-
-Controller: ('MaterialComponentController', 'ShowChildrenOnly')
+|Material Asset: ('Asset<MaterialAsset>', 'Visible')
 
 ]|Material Asset: ('Asset<MaterialAsset>', 'Visible')
 
-Enable LOD Materials: ('bool', 'Visible')
-
 ]|LOD Index: ('AZ::u64', 'Visible')
+
+]: ('EditorMaterialComponentSlot', 'ShowChildrenOnly')
+
+Default Material|Material Slot Stable Id: ('unsigned int', 'Visible')
+
+Default Material: ('EditorMaterialComponentSlot', 'ShowChildrenOnly')
+
+Default Material|Material Asset: ('Asset<MaterialAsset>', 'Visible')
 
 Default Material|LOD Index: ('AZ::u64', 'Visible')
 
 ]|Material Slot Stable Id: ('unsigned int', 'Visible')
 
-]: ('EditorMaterialComponentSlot', 'ShowChildrenOnly')
+|Material Slot Stable Id: ('unsigned int', 'Visible')
 
-|Material Asset: ('Asset<MaterialAsset>', 'Visible')
+Controller: ('MaterialComponentController', 'ShowChildrenOnly')
 
-Default Material: ('EditorMaterialComponentSlot', 'ShowChildrenOnly')
+|LOD Index: ('AZ::u64', 'Visible')
 
-Default Material|Material Asset: ('Asset<MaterialAsset>', 'Visible')
+Enable LOD Materials: ('bool', 'Visible')
 ```


### PR DESCRIPTION
Two fixes in o3dexport BlenderAddOn:
1- Textures that are supposed to be used as normal maps are
   guaranteed to have "_normal" infix in their file name
   so the O3DE Asset Processor treats them as normal vector
   data instead of color RGB data.

2- Fixes issues where Blender allows different
   textures named "Image" and "Image.png". In a situation
   like this they'll become "Image.png" and "Image111.png",
   and the DDD counter is automatically increased until there are
   no more collisions.

One Fix for o3dimport.py (The O3DE python script): 1- The script doesn't assume anymore that the material slot index
   follows the same sequence in both the FBX and the Material
   component. Now we search for the slot index using the Material Label.